### PR TITLE
Add reading order indicators to documentation cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,6 +59,24 @@
         .card a:hover {
             background: #7b3aab;
         }
+        .badge {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 4px;
+            font-size: 0.75em;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 12px;
+        }
+        .badge-start {
+            background: #10b981;
+            color: #fff;
+        }
+        .badge-reference {
+            background: #3b82f6;
+            color: #fff;
+        }
         .footer {
             text-align: center;
             margin-top: 40px;
@@ -73,12 +91,14 @@
         <p class="subtitle">QA Workflow Documentation for Pure Earth Labs</p>
 
         <div class="card">
+            <span class="badge badge-start">Start Here</span>
             <h2>QA Workflow Analysis</h2>
             <p>Complete analysis of Jen's 13-step QA process mapped to Monday.com, including gap analysis and recommendations.</p>
             <a href="/qa_workflow_analysis.html">View Analysis</a>
         </div>
 
         <div class="card">
+            <span class="badge badge-reference">Reference</span>
             <h2>Production Board Structure</h2>
             <p>Technical documentation of the Production board including columns, groups, views, and board relationships.</p>
             <a href="/production_board_structure.html">View Structure</a>


### PR DESCRIPTION
## Summary
- Add category badges to documentation cards for visual reading guidance
- "Start Here" (green) badge on QA Workflow Analysis card
- "Reference" (blue) badge on Production Board Structure card

## Test plan
- [ ] Verify badges display correctly on the live site after deployment
- [ ] Confirm badge colors have good contrast and accessibility

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)