### PR TITLE
Improve mobile responsiveness for stat cards and tables

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,29 @@
             opacity: 0.5;
             font-size: 0.9em;
         }
+
+        @media (max-width: 480px) {
+            body {
+                padding: 20px 10px;
+            }
+
+            h1 {
+                font-size: 1.5em;
+            }
+
+            .card {
+                padding: 20px;
+            }
+
+            .card h2 {
+                font-size: 1.2em;
+            }
+
+            .card a {
+                display: block;
+                text-align: center;
+            }
+        }
     </style>
 </head>
 <body>

--- a/docs/production_board_structure.html
+++ b/docs/production_board_structure.html
@@ -157,6 +157,72 @@
             margin-top: 30px;
             text-align: center;
         }
+
+        .table-wrapper {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 10px;
+            }
+
+            .header {
+                padding: 20px;
+            }
+
+            .header h1 {
+                font-size: 1.5em;
+            }
+
+            .meta-grid {
+                grid-template-columns: repeat(2, 1fr);
+            }
+
+            .meta-card .value {
+                font-size: 18px;
+            }
+
+            .section {
+                padding: 15px;
+            }
+
+            .views-grid {
+                grid-template-columns: 1fr;
+            }
+
+            table {
+                font-size: 14px;
+            }
+
+            th, td {
+                padding: 8px;
+            }
+
+            pre {
+                font-size: 12px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .meta-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .meta-card .value {
+                font-size: 16px;
+            }
+
+            th, td {
+                padding: 6px;
+            }
+
+            .badge {
+                font-size: 10px;
+                padding: 3px 6px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -312,6 +378,7 @@ flowchart LR
     <!-- Groups Table -->
     <div class="section">
         <h2>Groups (6)</h2>
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
@@ -360,11 +427,13 @@ flowchart LR
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>
 
     <!-- Columns Table -->
     <div class="section">
         <h2>Columns (36)</h2>
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
@@ -412,6 +481,7 @@ flowchart LR
                 <tr><td>PO(s)</td><td><code>lookup_mkvkmj5m</code></td><td><span class="badge badge-mirror">mirror</span></td></tr>
             </tbody>
         </table>
+        </div>
     </div>
 
     <!-- Views -->
@@ -496,6 +566,7 @@ flowchart LR
     <!-- Owners -->
     <div class="section">
         <h2>Board Owners</h2>
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
@@ -517,6 +588,7 @@ flowchart LR
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>
 
     <!-- API Reference -->

--- a/docs/qa_workflow_analysis.html
+++ b/docs/qa_workflow_analysis.html
@@ -289,6 +289,108 @@
             background: #df2f4a;
             border-color: #df2f4a;
         }
+
+        .table-wrapper {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 10px;
+            }
+
+            .header {
+                padding: 20px;
+            }
+
+            .header h1 {
+                font-size: 1.8em;
+            }
+
+            .header .subtitle {
+                font-size: 1em;
+            }
+
+            .section {
+                padding: 15px;
+            }
+
+            .user-story {
+                padding: 15px;
+                font-size: 1em;
+            }
+
+            .workflow-step {
+                flex-direction: column;
+            }
+
+            .step-number {
+                min-width: unset;
+                padding: 10px;
+                font-size: 1.2em;
+            }
+
+            .step-status {
+                padding: 10px;
+            }
+
+            .recommendations {
+                grid-template-columns: 1fr;
+            }
+
+            .column-list {
+                grid-template-columns: 1fr;
+            }
+
+            table {
+                font-size: 14px;
+            }
+
+            th, td {
+                padding: 10px 8px;
+            }
+
+            .gap-card, .exists-card {
+                padding: 15px;
+            }
+
+            div[style*="grid-template-columns: 1fr 1fr"] {
+                display: block !important;
+            }
+
+            div[style*="grid-template-columns: 1fr 1fr"] > div {
+                margin-bottom: 15px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .header h1 {
+                font-size: 1.5em;
+            }
+
+            .status-badge {
+                font-size: 10px;
+                padding: 3px 8px;
+            }
+
+            th, td {
+                padding: 8px 6px;
+            }
+
+            .board-card {
+                padding: 15px;
+            }
+
+            .rec-card {
+                padding: 15px;
+            }
+
+            code {
+                font-size: 0.8em;
+                padding: 1px 4px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -624,6 +726,7 @@ flowchart TB
     style M5 fill:#fdab3d,color:#000
         </div>
 
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
@@ -678,12 +781,14 @@ flowchart TB
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>
 
     <!-- Items in QA Status -->
     <div class="section">
         <h2>Current Items in QA Status</h2>
         <p>These 7 items are currently in QA status but have no QA documentation attached:</p>
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
@@ -730,6 +835,7 @@ flowchart TB
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>
 
     <!-- Proposed Solution -->


### PR DESCRIPTION
## Summary
- Add CSS media queries for mobile viewports (768px and 480px breakpoints)
- Wrap all tables in scrollable containers (`overflow-x: auto`) to prevent horizontal page overflow
- Make stat cards wrap to 2-column on tablet, 1-column on mobile
- Improve workflow step cards to stack vertically on mobile
- Scale fonts, padding, and badges appropriately for smaller screens

## Files Changed
- `docs/index.html` - Added mobile media queries
- `docs/production_board_structure.html` - Added responsive CSS and table wrappers
- `docs/qa_workflow_analysis.html` - Added responsive CSS and table wrappers

## Test plan
- [ ] Test at 375px width (iPhone SE)
- [ ] Test at 414px width (iPhone Plus)
- [ ] Verify stat cards wrap gracefully on mobile
- [ ] Verify tables are scrollable without breaking page layout
- [ ] Verify no horizontal page overflow on any screen size
- [ ] Verify mermaid flow diagrams scale appropriately

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)