### PR TITLE
Add TL;DR executive summaries to content pages

### DIFF
--- a/docs/ideal_candidate_profile.html
+++ b/docs/ideal_candidate_profile.html
@@ -309,6 +309,31 @@
 
         a { color: #66ccff; }
 
+        .tldr {
+            background: var(--color-surface-raised, #1e2a47);
+            border-left: 4px solid var(--color-accent, #9d50dd);
+            padding: var(--space-6, 1.5rem);
+            margin: var(--space-8, 2rem) 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .tldr h2 {
+            font-size: var(--text-lg, 1.125rem);
+            margin: 0 0 var(--space-4, 1rem) 0;
+            color: var(--color-accent, #9d50dd);
+        }
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .tldr li {
+            margin: 8px 0;
+        }
+        .tldr .read-time {
+            margin: var(--space-4, 1rem) 0 0 0;
+            font-size: var(--text-sm, 0.875rem);
+            color: var(--color-text-muted, #a0a0a0);
+        }
+
         .vs-table {
             margin: 20px 0;
         }
@@ -341,6 +366,17 @@
         <div class="subtitle">QA Compliance Coordinator for Pure Earth Labs</div>
         <div class="date">Generated: December 8, 2025 | Based on Workflow Gap Analysis</div>
     </div>
+
+    <section class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Role: QA Compliance Coordinator</strong> - Enforces the process Jen designed, doesn't replace her</li>
+            <li><strong>Key skills: Monday.com admin + enforcement mindset</strong> - Must configure automations and hold the line on compliance</li>
+            <li><strong>Reports to: Production leadership</strong> - Works alongside Jen (floor QA) to ensure documentation compliance</li>
+            <li><strong>90-day goal: 40% to 90% QA DOCS completion</strong> - Through owner assignment and FULFILLED blocking</li>
+        </ul>
+        <p class="read-time">Full read: ~10 minutes</p>
+    </section>
 
     <!-- The Problem -->
     <div class="section">

--- a/docs/next_steps_roadmap.html
+++ b/docs/next_steps_roadmap.html
@@ -237,6 +237,31 @@
 
         a { color: #66ccff; }
 
+        .tldr {
+            background: var(--color-surface-raised, #1e2a47);
+            border-left: 4px solid var(--color-accent, #9d50dd);
+            padding: var(--space-6, 1.5rem);
+            margin: var(--space-8, 2rem) 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .tldr h2 {
+            font-size: var(--text-lg, 1.125rem);
+            margin: 0 0 var(--space-4, 1rem) 0;
+            color: var(--color-accent, #9d50dd);
+        }
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .tldr li {
+            margin: 8px 0;
+        }
+        .tldr .read-time {
+            margin: var(--space-4, 1rem) 0 0 0;
+            font-size: var(--text-sm, 0.875rem);
+            color: var(--color-text-muted, #a0a0a0);
+        }
+
         .phase-header {
             display: flex;
             align-items: center;
@@ -317,6 +342,17 @@
         <div class="subtitle">QA Workflow Improvement Plan for Pure Earth Labs</div>
         <div class="date">Generated: December 8, 2025 | Based on Team Performance Analysis</div>
     </div>
+
+    <section class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Phase 1: Fix ownership</strong> - Assign owners to all 60 unassigned items, then enforce going forward</li>
+            <li><strong>Phase 2: Block incomplete FULFILLED</strong> - Add Monday.com automation requiring QA DOCS before status change</li>
+            <li><strong>Target: 40% to 95% QA DOCS compliance</strong> - Expected within 8 weeks of implementation</li>
+            <li><strong>4-phase rollout over ~4 weeks</strong> - Foundation, Enforcement, Visibility, Cleanup</li>
+        </ul>
+        <p class="read-time">Full read: ~10 minutes</p>
+    </section>
 
     <!-- Assessment Summary -->
     <div class="section">

--- a/docs/production_board_structure.html
+++ b/docs/production_board_structure.html
@@ -335,6 +335,31 @@
                 padding: 3px 6px;
             }
         }
+
+        .tldr {
+            background: var(--color-surface-raised, #1e2a47);
+            border-left: 4px solid var(--color-accent, #9d50dd);
+            padding: var(--space-6, 1.5rem);
+            margin: var(--space-8, 2rem) 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .tldr h2 {
+            font-size: var(--text-lg, 1.125rem);
+            margin: 0 0 var(--space-4, 1rem) 0;
+            color: var(--color-accent, #9d50dd);
+        }
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .tldr li {
+            margin: 8px 0;
+        }
+        .tldr .read-time {
+            margin: var(--space-4, 1rem) 0 0 0;
+            font-size: var(--text-sm, 0.875rem);
+            color: var(--color-text-muted, #a0a0a0);
+        }
     </style>
 </head>
 <body>
@@ -357,6 +382,17 @@
         <h1>Production Board Documentation</h1>
         <p>Monday.com Board Structure & Data Flow Analysis</p>
     </div>
+
+    <section class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Board ID: 9304930311</strong> - Production board with 123 items across 6 workflow groups</li>
+            <li><strong>Key column: QA DOCS</strong> - <code>file_mktcs58s</code> is where QA inspection reports should be attached</li>
+            <li><strong>5 connected boards</strong> - Prod Deals, EPOs Materials, BBT, Equipment, and Subitems</li>
+            <li><strong>36 columns, 18 views</strong> - Including mirrors from BBT for bulk status and materials tracking</li>
+        </ul>
+        <p class="read-time">Full read: ~5 minutes</p>
+    </section>
 
     <!-- Board Metadata -->
     <div class="meta-grid">

--- a/docs/qa_workflow_analysis.html
+++ b/docs/qa_workflow_analysis.html
@@ -500,6 +500,31 @@
                 padding: 1px 4px;
             }
         }
+
+        .tldr {
+            background: var(--color-surface-raised, #1e2a47);
+            border-left: 4px solid var(--color-accent, #9d50dd);
+            padding: var(--space-6, 1.5rem);
+            margin: var(--space-8, 2rem) 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .tldr h2 {
+            font-size: var(--text-lg, 1.125rem);
+            margin: 0 0 var(--space-4, 1rem) 0;
+            color: var(--color-accent, #9d50dd);
+        }
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .tldr li {
+            margin: 8px 0;
+        }
+        .tldr .read-time {
+            margin: var(--space-4, 1rem) 0 0 0;
+            font-size: var(--text-sm, 0.875rem);
+            color: var(--color-text-muted, #a0a0a0);
+        }
     </style>
 </head>
 <body>
@@ -523,6 +548,17 @@
         <div class="subtitle">Mapping Jen's 13-Step QA Process to Monday.com</div>
         <div class="date">Generated: December 8, 2025</div>
     </div>
+
+    <section class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Jen's 13-step QA process maps to Monday.com with gaps</strong> - Process documented, but tooling incomplete</li>
+            <li><strong>Critical gap: No QA Inspection Report template link</strong> - Jen must manually find templates in Google Drive</li>
+            <li><strong>QA DOCS column exists but is empty</strong> - 0 of 7 items in QA status have documentation attached</li>
+            <li><strong>Main recommendation: Add enforcement automations</strong> - Block FULFILLED without QA DOCS</li>
+        </ul>
+        <p class="read-time">Full read: ~12 minutes</p>
+    </section>
 
     <!-- User Story -->
     <div class="section">

--- a/docs/team_performance_analysis.html
+++ b/docs/team_performance_analysis.html
@@ -251,6 +251,31 @@
         }
 
         a { color: #66ccff; }
+
+        .tldr {
+            background: var(--color-surface-raised, #1e2a47);
+            border-left: 4px solid var(--color-accent, #9d50dd);
+            padding: var(--space-6, 1.5rem);
+            margin: var(--space-8, 2rem) 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .tldr h2 {
+            font-size: var(--text-lg, 1.125rem);
+            margin: 0 0 var(--space-4, 1rem) 0;
+            color: var(--color-accent, #9d50dd);
+        }
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .tldr li {
+            margin: 8px 0;
+        }
+        .tldr .read-time {
+            margin: var(--space-4, 1rem) 0 0 0;
+            font-size: var(--text-sm, 0.875rem);
+            color: var(--color-text-muted, #a0a0a0);
+        }
     </style>
 </head>
 <body>
@@ -270,6 +295,17 @@
         <div class="subtitle">FULFILLED Items Data Quality Report - Production Board</div>
         <div class="date">Generated: December 8, 2025 | Data Source: Monday.com API</div>
     </div>
+
+    <section class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>60% of FULFILLED items missing QA DOCS</strong> - 57 of 95 items have no documentation attached</li>
+            <li><strong>63% have no owner assigned</strong> - No accountability for documentation gaps</li>
+            <li><strong>Owner assignment = 2.7x better compliance</strong> - Items with owners have 67% QA DOCS rate vs 25% unassigned</li>
+            <li><strong>Top performer: Moo Elixir team</strong> - 67% QA DOCS, 100% Spec Sheet completion</li>
+        </ul>
+        <p class="read-time">Full read: ~8 minutes</p>
+    </section>
 
     <!-- Executive Summary -->
     <div class="section">


### PR DESCRIPTION
## Summary
- Add TL;DR executive summary sections to 5 content pages for stakeholders who need the gist in 30 seconds
- Each summary includes 4 key bullet points extracted from actual page content
- Each summary includes estimated full read time

## Pages Updated
- `team_performance_analysis.html` - Key stats: 60% missing QA DOCS, 63% unassigned
- `qa_workflow_analysis.html` - Gap analysis: process exists but tooling incomplete
- `next_steps_roadmap.html` - 4-phase improvement plan over ~4 weeks
- `production_board_structure.html` - Board ID, key columns, connected boards
- `ideal_candidate_profile.html` - QA Compliance Coordinator role requirements

## Design Pattern
Consistent styling across all pages:
- Purple accent border on left
- Raised surface background
- 3-4 bullet points max
- Read time estimate at bottom

## Test plan
- [ ] View each page and verify TL;DR appears after header
- [ ] Check styling is consistent across all 5 pages
- [ ] Verify bullet points are accurate to page content
- [ ] Confirm read time estimates are reasonable

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)