### PR TITLE
Add TL;DR sections with anchors to all content pages

### DIFF
--- a/docs/ideal_candidate_profile.html
+++ b/docs/ideal_candidate_profile.html
@@ -315,6 +315,57 @@
 
         a { color: #66ccff; }
 
+        .tldr {
+            background: linear-gradient(135deg, rgba(0, 200, 117, 0.15) 0%, rgba(87, 155, 252, 0.1) 100%);
+            border: 1px solid var(--good);
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: var(--good);
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: var(--good);
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(0, 200, 117, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: var(--info);
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
+
         .vs-table {
             margin: 20px 0;
         }
@@ -347,6 +398,17 @@
         <div class="subtitle">QA Compliance Coordinator for Pure Earth Labs</div>
         <div class="date">Generated: December 8, 2025 | Based on Workflow Gap Analysis</div>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Role:</strong> QA Compliance Coordinator - enforces existing process, not floor QA</li>
+            <li><strong>3 must-haves:</strong> Monday.com admin skills, enforcement mindset, data analysis</li>
+            <li><strong>Reports to:</strong> Production Manager (supports Jen's floor QA work)</li>
+            <li><strong>90-day goal:</strong> QA DOCS 40% → 90%, Owner assignment 37% → 100%</li>
+        </ul>
+        <p class="read-time">Full read: ~10 minutes | <a href="/next_steps_roadmap.html">See Implementation Roadmap</a></p>
+    </section>
 
     <!-- The Problem -->
     <div class="section">

--- a/docs/next_steps_roadmap.html
+++ b/docs/next_steps_roadmap.html
@@ -243,6 +243,57 @@
 
         a { color: #66ccff; }
 
+        .tldr {
+            background: linear-gradient(135deg, rgba(157, 80, 221, 0.15) 0%, rgba(87, 155, 252, 0.1) 100%);
+            border: 1px solid var(--purple);
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: var(--purple);
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: var(--good);
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(157, 80, 221, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: var(--info);
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
+
         .phase-header {
             display: flex;
             align-items: center;
@@ -323,6 +374,17 @@
         <div class="subtitle">QA Workflow Improvement Plan for Pure Earth Labs</div>
         <div class="date">Generated: December 8, 2025 | Based on Team Performance Analysis</div>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Priority 1:</strong> Assign owners + block FULFILLED without QA DOCS (fix 60% gap)</li>
+            <li><strong>4 phases:</strong> Foundation, Enforcement, Visibility, Cleanup (~8 weeks total)</li>
+            <li><strong>Target:</strong> QA DOCS completion 40% → 95%, Owner assignment 37% → 100%</li>
+            <li><strong>Quick win:</strong> Items with owners are 2.7x more likely to have complete docs</li>
+        </ul>
+        <p class="read-time">Full read: ~10 minutes | <a href="/ideal_candidate_profile.html">See Hiring Profile</a></p>
+    </section>
 
     <!-- Assessment Summary -->
     <div class="section">

--- a/docs/production_board_structure.html
+++ b/docs/production_board_structure.html
@@ -267,6 +267,57 @@
             text-decoration: underline;
         }
 
+        .tldr {
+            background: linear-gradient(135deg, rgba(102, 126, 234, 0.15) 0%, rgba(118, 75, 162, 0.1) 100%);
+            border: 1px solid #667eea;
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: #667eea;
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: #667eea;
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(102, 126, 234, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: #66ccff;
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
+
         .table-wrapper {
             overflow-x: auto;
             -webkit-overflow-scrolling: touch;
@@ -354,6 +405,17 @@
         <h1>Production Board Documentation</h1>
         <p>Monday.com Board Structure & Data Flow Analysis</p>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>Board ID:</strong> 9304930311 | 123 items | 36 columns | 18 views</li>
+            <li><strong>Key column:</strong> QA DOCS (<code>file_mktcs58s</code>) - where QA reports attach</li>
+            <li><strong>5 related boards:</strong> Prod Deals, EPOs-Materials, BBT, Equipment, Subitems</li>
+            <li><strong>6 groups:</strong> Blocked → Lab Bulk → This Week → Next Week → Future → Completed</li>
+        </ul>
+        <p class="read-time">Full read: ~5 minutes | <a href="/qa_workflow_analysis.html">See Workflow Analysis</a></p>
+    </section>
 
     <!-- Board Metadata -->
     <div class="meta-grid">

--- a/docs/qa_manager_procedure.html
+++ b/docs/qa_manager_procedure.html
@@ -385,6 +385,57 @@
 
         ul, ol { margin: 10px 0; padding-left: 25px; }
         li { margin: 8px 0; }
+
+        .tldr {
+            background: linear-gradient(135deg, rgba(157, 80, 221, 0.15) 0%, rgba(87, 155, 252, 0.1) 100%);
+            border: 1px solid var(--purple);
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: var(--purple);
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: var(--green);
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(157, 80, 221, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
     </style>
 </head>
 <body>
@@ -404,6 +455,17 @@
         <div class="subtitle">Complete Standard Operating Procedure for Production QA</div>
         <div class="meta">Pure Earth Labs | Loom Training Script Reference</div>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>13 steps</strong> across 4 phases: Preparation, Pre-Run, In-Process, Final</li>
+            <li><strong>5 non-negotiables:</strong> Spec sheet at line, MO/batch match, retention sample comparison, close-out steps, Monday.com attachment</li>
+            <li><strong>Key output:</strong> QA Inspection Report uploaded to <a href="#step-13">QA DOCS column</a> in Monday.com</li>
+            <li><strong>Time estimate:</strong> ~15-30 min per production run (varies by complexity)</li>
+        </ul>
+        <p class="read-time">Full read: ~12 minutes</p>
+    </section>
 
     <!-- Overview Flowchart -->
     <div class="section">

--- a/docs/qa_workflow_analysis.html
+++ b/docs/qa_workflow_analysis.html
@@ -360,6 +360,57 @@
             text-decoration: underline;
         }
 
+        .tldr {
+            background: linear-gradient(135deg, rgba(157, 80, 221, 0.15) 0%, rgba(223, 47, 74, 0.1) 100%);
+            border: 1px solid var(--purple);
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: var(--purple);
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: var(--gap-red);
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(157, 80, 221, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: var(--info-blue);
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
+
         .checklist {
             background: #0f0f23;
             border-radius: 8px;
@@ -523,6 +574,17 @@
         <div class="subtitle">Mapping Jen's 13-Step QA Process to Monday.com</div>
         <div class="date">Generated: December 8, 2025</div>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>2 critical gaps:</strong> No QA template link in Monday.com, QA DOCS column never used</li>
+            <li><strong>4 boards</strong> involved: Production, BBT, Finalization, EPOs-Materials</li>
+            <li><strong>7 items</strong> currently in QA status with zero documentation attached</li>
+            <li><strong>Fix priority:</strong> Add QA template link, enforce QA DOCS upload before FULFILLED</li>
+        </ul>
+        <p class="read-time">Full read: ~10 minutes | <a href="/production_board_structure.html">See Board Structure</a></p>
+    </section>
 
     <!-- User Story -->
     <div class="section">

--- a/docs/team_performance_analysis.html
+++ b/docs/team_performance_analysis.html
@@ -257,6 +257,57 @@
         }
 
         a { color: #66ccff; }
+
+        .tldr {
+            background: linear-gradient(135deg, rgba(223, 47, 74, 0.15) 0%, rgba(253, 171, 61, 0.1) 100%);
+            border: 1px solid var(--critical);
+            border-radius: 12px;
+            padding: 25px 30px;
+            margin-bottom: 30px;
+        }
+
+        .tldr h2 {
+            margin: 0 0 15px 0;
+            color: var(--critical);
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .tldr h2::before {
+            content: "⚡";
+        }
+
+        .tldr ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .tldr li {
+            margin: 10px 0;
+        }
+
+        .tldr strong {
+            color: var(--critical);
+        }
+
+        .tldr .read-time {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(223, 47, 74, 0.3);
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .tldr a {
+            color: var(--info);
+            text-decoration: none;
+        }
+
+        .tldr a:hover {
+            text-decoration: underline;
+        }
     </style>
 </head>
 <body>
@@ -276,6 +327,17 @@
         <div class="subtitle">FULFILLED Items Data Quality Report - Production Board</div>
         <div class="date">Generated: December 8, 2025 | Data Source: Monday.com API</div>
     </div>
+
+    <section id="tldr" class="tldr">
+        <h2>TL;DR</h2>
+        <ul>
+            <li><strong>60%</strong> of FULFILLED items are missing QA documentation</li>
+            <li><strong>63%</strong> have no owner assigned (root cause of compliance gap)</li>
+            <li><strong>Key insight:</strong> Items with owners are 2.7x more likely to have complete docs</li>
+            <li><strong>Action needed:</strong> Block FULFILLED status without QA DOCS, require owner assignment</li>
+        </ul>
+        <p class="read-time">Full read: ~8 minutes | <a href="/next_steps_roadmap.html">See Roadmap</a></p>
+    </section>
 
     <!-- Executive Summary -->
     <div class="section">


### PR DESCRIPTION
## Summary
- Add standardized TL;DR section with `#tldr` anchor to all 6 content pages
- Each TL;DR includes 3-5 bullet points with key metrics/takeaways
- Consistent styling with visual distinction (gradient background, colored border)
- Read time estimates and cross-links to related pages included
- TL;DR positioned within first viewport (no scrolling needed)

## Pages Updated

| Page | TL;DR Highlights |
|------|------------------|
| QA Procedure | 13 steps, 4 phases, 5 non-negotiables, time estimate |
| Performance | 60% missing docs, 63% no owner, 2.7x insight |
| Workflow | 2 critical gaps, 4 boards, 7 items in QA status |
| Roadmap | Priority 1 action, 4 phases, target metrics |
| Board Structure | Board ID, key QA DOCS column, 5 related boards |
| Candidate | Role title, 3 must-haves, reports to, 90-day goal |

## Test plan
- [ ] Verify `#tldr` anchor works on all 6 pages (e.g., `/qa_manager_procedure.html#tldr`)
- [ ] Confirm TL;DR visible without scrolling on each page
- [ ] Check styling consistency across pages
- [ ] Verify all cross-links work correctly

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)