### PR TITLE
Persist persona selection across pages with localStorage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -403,7 +403,7 @@
 
     <script>
         (function() {
-            const STORAGE_KEY = 'jen-qa-audience';
+            const STORAGE_KEY = 'jen-qa-persona';
             const audienceBtns = document.querySelectorAll('.audience-btn');
             const clearBtn = document.querySelector('.clear-filter');
             const cards = document.querySelectorAll('.card[data-audiences]');


### PR DESCRIPTION
## Summary
- Updates the localStorage key from `jen-qa-audience` to `jen-qa-persona` to match the specification in issue #48

The localStorage persistence functionality was already implemented in the codebase:
- Saves selected persona to localStorage on button click
- Restores persona selection on page load
- Clears localStorage when "Show All" is clicked

## Test plan
- [ ] Select "Stakeholder" persona on homepage
- [ ] Navigate to any other page
- [ ] Return to homepage
- [ ] Verify "Stakeholder" is still selected and content is filtered
- [ ] Click "Show All" / "Clear selection"
- [ ] Refresh page
- [ ] Verify no persona is pre-selected

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)