### PR TITLE
Add floating back-to-top button on long pages

### DIFF
--- a/docs/ideal_candidate_profile.html
+++ b/docs/ideal_candidate_profile.html
@@ -399,6 +399,34 @@
             color: var(--purple);
             font-size: 1.1em;
         }
+        .back-to-top {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            background: rgba(157, 80, 221, 0.9);
+            color: white;
+            border: none;
+            cursor: pointer;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s ease, visibility 0.3s ease;
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .back-to-top.visible {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .back-to-top:hover {
+            background: rgba(157, 80, 221, 1);
+        }
     </style>
     <link rel="stylesheet" href="/css/share.css">
 </head>
@@ -985,7 +1013,27 @@ flowchart LR
             }
         });
     </script>
+    <button class="back-to-top" aria-label="Back to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+    </button>
     <script src="/js/share.js"></script>
     <script src="/js/related-pages.js"></script>
+    <script>
+        (function() {
+            const backToTop = document.querySelector('.back-to-top');
+            window.addEventListener('scroll', function() {
+                if (window.scrollY > 400) {
+                    backToTop.classList.add('visible');
+                } else {
+                    backToTop.classList.remove('visible');
+                }
+            });
+            backToTop.addEventListener('click', function() {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/docs/qa_manager_procedure.html
+++ b/docs/qa_manager_procedure.html
@@ -490,6 +490,34 @@
         .tldr a:hover {
             text-decoration: underline;
         }
+        .back-to-top {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            background: rgba(157, 80, 221, 0.9);
+            color: white;
+            border: none;
+            cursor: pointer;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s ease, visibility 0.3s ease;
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .back-to-top.visible {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .back-to-top:hover {
+            background: rgba(157, 80, 221, 1);
+        }
     </style>
     <link rel="stylesheet" href="/css/share.css">
 </head>
@@ -1334,8 +1362,28 @@ flowchart LR
             }
         });
     </script>
+    <button class="back-to-top" aria-label="Back to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+    </button>
     <script src="/js/share.js"></script>
     <script src="/js/breadcrumbs.js"></script>
     <script src="/js/related-pages.js"></script>
+    <script>
+        (function() {
+            const backToTop = document.querySelector('.back-to-top');
+            window.addEventListener('scroll', function() {
+                if (window.scrollY > 400) {
+                    backToTop.classList.add('visible');
+                } else {
+                    backToTop.classList.remove('visible');
+                }
+            });
+            backToTop.addEventListener('click', function() {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/docs/qa_workflow_analysis.html
+++ b/docs/qa_workflow_analysis.html
@@ -570,6 +570,34 @@
                 padding: 1px 4px;
             }
         }
+        .back-to-top {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            background: rgba(157, 80, 221, 0.9);
+            color: white;
+            border: none;
+            cursor: pointer;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s ease, visibility 0.3s ease;
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .back-to-top.visible {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .back-to-top:hover {
+            background: rgba(157, 80, 221, 1);
+        }
     </style>
     <link rel="stylesheet" href="/css/share.css">
 </head>
@@ -1198,7 +1226,27 @@ flowchart LR
             }
         });
     </script>
+    <button class="back-to-top" aria-label="Back to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+    </button>
     <script src="/js/share.js"></script>
     <script src="/js/related-pages.js"></script>
+    <script>
+        (function() {
+            const backToTop = document.querySelector('.back-to-top');
+            window.addEventListener('scroll', function() {
+                if (window.scrollY > 400) {
+                    backToTop.classList.add('visible');
+                } else {
+                    backToTop.classList.remove('visible');
+                }
+            });
+            backToTop.addEventListener('click', function() {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/docs/team_performance_analysis.html
+++ b/docs/team_performance_analysis.html
@@ -325,6 +325,34 @@
         .tldr a:hover {
             text-decoration: underline;
         }
+        .back-to-top {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            background: rgba(157, 80, 221, 0.9);
+            color: white;
+            border: none;
+            cursor: pointer;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s ease, visibility 0.3s ease;
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .back-to-top.visible {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .back-to-top:hover {
+            background: rgba(157, 80, 221, 1);
+        }
     </style>
     <link rel="stylesheet" href="/css/share.css">
 </head>
@@ -877,7 +905,27 @@ Fields checked: QA DOCS, Spec Sheet, Owners, QTY, PRODUCED, DAY, LINE
             }
         });
     </script>
+    <button class="back-to-top" aria-label="Back to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+    </button>
     <script src="/js/share.js"></script>
     <script src="/js/related-pages.js"></script>
+    <script>
+        (function() {
+            const backToTop = document.querySelector('.back-to-top');
+            window.addEventListener('scroll', function() {
+                if (window.scrollY > 400) {
+                    backToTop.classList.add('visible');
+                } else {
+                    backToTop.classList.remove('visible');
+                }
+            });
+            backToTop.addEventListener('click', function() {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added a floating "back to top" button to all long pages in the site
- Button appears after scrolling down ~400px from the top
- Smoothly scrolls back to the top when clicked
- Styled with the site's purple theme color

## Pages Updated
- `qa_manager_procedure.html` (primary - longest page)
- `team_performance_analysis.html`
- `qa_workflow_analysis.html`
- `ideal_candidate_profile.html`

## Implementation Details
- Fixed position in bottom-right corner (2rem from edges)
- 44x44px circular button with up arrow SVG
- Smooth fade in/out transition (0.3s)
- Hover state with full opacity purple
- Accessible with `aria-label="Back to top"`

## Test plan
- [ ] Open `qa_manager_procedure.html`
- [ ] Scroll down past the TL;DR section (~400px)
- [ ] Verify back-to-top button appears in bottom-right
- [ ] Click the button
- [ ] Verify smooth scroll to top
- [ ] Verify button disappears when at top
- [ ] Test on mobile - button should not obstruct content

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)