### PR TITLE
Tighten mobile step indicator layout

### DIFF
--- a/docs/js/breadcrumbs.js
+++ b/docs/js/breadcrumbs.js
@@ -335,6 +335,47 @@
                     display: none !important;
                 }
             }
+
+            @media (max-width: 480px) {
+                .breadcrumb-bar {
+                    padding: 6px 12px;
+                }
+
+                .breadcrumb-content {
+                    flex-direction: row;
+                    align-items: center;
+                    gap: 0;
+                }
+
+                .breadcrumb-trail {
+                    display: none;
+                }
+
+                .breadcrumb-progress {
+                    width: 100%;
+                    justify-content: center;
+                    gap: 10px;
+                }
+
+                .phase-indicator {
+                    gap: 4px;
+                }
+
+                .phase-dot {
+                    width: 20px;
+                    height: 20px;
+                    border-width: 2px;
+                }
+
+                .phase-dot-inner {
+                    width: 8px;
+                    height: 8px;
+                }
+
+                .breadcrumb-counter {
+                    font-size: 0.85em;
+                }
+            }
         `;
         document.head.appendChild(style);
     }


### PR DESCRIPTION
## Summary
- Adds compact mobile styling for step indicator at 480px breakpoint
- Hides breadcrumb trail, centers phase dots with step counter
- Reduces phase dot sizes from 28px to 20px with tighter 4px gaps
- Reduces vertical space with smaller bar padding

## Test plan
- [ ] Open `qa_manager_procedure.html` at 375px width
- [ ] Verify step indicator shows centered `[●○○○] Step 0 of 13` layout
- [ ] Navigate between steps to verify indicator updates
- [ ] Check at 414px and 480px breakpoints
- [ ] Verify desktop layout (>768px) is unchanged

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)