### PR TITLE
Add mobile nav scroll affordance

### DIFF
--- a/docs/css/share.css
+++ b/docs/css/share.css
@@ -139,3 +139,41 @@ h3:hover .copy-link-btn {
         padding-right: 1rem;
     }
 }
+
+/* ===========================================
+   MOBILE NAV SCROLL AFFORDANCE
+   Visual indicator for horizontally scrollable nav
+   =========================================== */
+
+.nav-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    position: relative;
+}
+
+.nav-scroll::-webkit-scrollbar {
+    display: none;
+}
+
+.nav-scroll-container {
+    position: relative;
+}
+
+.nav-scroll-container::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 40px;
+    background: linear-gradient(to right, transparent, #0f0f23);
+    pointer-events: none;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+}
+
+.nav-scroll-container.scrolled-end::after {
+    opacity: 0;
+}

--- a/docs/ideal_candidate_profile.html
+++ b/docs/ideal_candidate_profile.html
@@ -431,14 +431,16 @@
     <link rel="stylesheet" href="/css/share.css">
 </head>
 <body>
-<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a;">
-    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500;">← Home</a>
-    <div style="display: flex; gap: 20px; font-size: 0.9em;">
-        <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Procedure</a>
-        <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Analysis</a>
-        <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Performance</a>
-        <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Roadmap</a>
-        <a href="./ideal_candidate_profile.html" style="color: #00c875; text-decoration: none; font-weight: 500;">Candidate</a>
+<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a; gap: 12px;">
+    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500; white-space: nowrap; flex-shrink: 0;">← Home</a>
+    <div class="nav-scroll-container" style="overflow: hidden; flex: 1; min-width: 0;">
+        <div class="nav-scroll" style="display: flex; gap: 20px; font-size: 0.9em; padding-right: 20px;">
+            <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Procedure</a>
+            <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Analysis</a>
+            <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Performance</a>
+            <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Roadmap</a>
+            <a href="./ideal_candidate_profile.html" style="color: #00c875; text-decoration: none; font-weight: 500; white-space: nowrap;">Candidate</a>
+        </div>
     </div>
 </nav>
     <div class="header">

--- a/docs/js/share.js
+++ b/docs/js/share.js
@@ -114,9 +114,27 @@
         }, 2000);
     }
 
+    function setupNavScrollAffordance() {
+        var scrollContainers = document.querySelectorAll('.nav-scroll-container');
+        scrollContainers.forEach(function(container) {
+            var scrollArea = container.querySelector('.nav-scroll');
+            if (!scrollArea) return;
+
+            function checkScrollEnd() {
+                var isAtEnd = scrollArea.scrollLeft + scrollArea.clientWidth >= scrollArea.scrollWidth - 5;
+                container.classList.toggle('scrolled-end', isAtEnd);
+            }
+
+            checkScrollEnd();
+            scrollArea.addEventListener('scroll', checkScrollEnd);
+            window.addEventListener('resize', checkScrollEnd);
+        });
+    }
+
     function init() {
         setupCopyButtons();
         highlightAnchor();
+        setupNavScrollAffordance();
 
         window.addEventListener('hashchange', highlightAnchor);
     }

--- a/docs/next_steps_roadmap.html
+++ b/docs/next_steps_roadmap.html
@@ -378,14 +378,16 @@
     <link rel="stylesheet" href="/css/share.css">
 </head>
 <body>
-<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a;">
-    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500;">← Home</a>
-    <div style="display: flex; gap: 20px; font-size: 0.9em;">
-        <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Procedure</a>
-        <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Analysis</a>
-        <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Performance</a>
-        <a href="./next_steps_roadmap.html" style="color: #00c875; text-decoration: none; font-weight: 500;">Roadmap</a>
-        <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Candidate</a>
+<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a; gap: 12px;">
+    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500; white-space: nowrap; flex-shrink: 0;">← Home</a>
+    <div class="nav-scroll-container" style="overflow: hidden; flex: 1; min-width: 0;">
+        <div class="nav-scroll" style="display: flex; gap: 20px; font-size: 0.9em; padding-right: 20px;">
+            <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Procedure</a>
+            <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Analysis</a>
+            <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Performance</a>
+            <a href="./next_steps_roadmap.html" style="color: #00c875; text-decoration: none; font-weight: 500; white-space: nowrap;">Roadmap</a>
+            <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Candidate</a>
+        </div>
     </div>
 </nav>
     <div class="header">

--- a/docs/qa_manager_procedure.html
+++ b/docs/qa_manager_procedure.html
@@ -522,14 +522,16 @@
     <link rel="stylesheet" href="/css/share.css">
 </head>
 <body>
-<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a;">
-    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500;">← Home</a>
-    <div style="display: flex; gap: 20px; font-size: 0.9em;">
-        <a href="./qa_manager_procedure.html" style="color: #00c875; text-decoration: none; font-weight: 500;">Procedure</a>
-        <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Analysis</a>
-        <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Performance</a>
-        <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Roadmap</a>
-        <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Candidate</a>
+<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a; gap: 12px;">
+    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500; white-space: nowrap; flex-shrink: 0;">← Home</a>
+    <div class="nav-scroll-container" style="overflow: hidden; flex: 1; min-width: 0;">
+        <div class="nav-scroll" style="display: flex; gap: 20px; font-size: 0.9em; padding-right: 20px;">
+            <a href="./qa_manager_procedure.html" style="color: #00c875; text-decoration: none; font-weight: 500; white-space: nowrap;">Procedure</a>
+            <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Analysis</a>
+            <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Performance</a>
+            <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Roadmap</a>
+            <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Candidate</a>
+        </div>
     </div>
 </nav>
     <div class="header">

--- a/docs/qa_workflow_analysis.html
+++ b/docs/qa_workflow_analysis.html
@@ -602,14 +602,16 @@
     <link rel="stylesheet" href="/css/share.css">
 </head>
 <body>
-<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a;">
-    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500;">← Home</a>
-    <div style="display: flex; gap: 20px; font-size: 0.9em;">
-        <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Procedure</a>
-        <a href="./qa_workflow_analysis.html" style="color: #00c875; text-decoration: none; font-weight: 500;">Workflow</a>
-        <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Performance</a>
-        <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Roadmap</a>
-        <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Candidate</a>
+<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a; gap: 12px;">
+    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500; white-space: nowrap; flex-shrink: 0;">← Home</a>
+    <div class="nav-scroll-container" style="overflow: hidden; flex: 1; min-width: 0;">
+        <div class="nav-scroll" style="display: flex; gap: 20px; font-size: 0.9em; padding-right: 20px;">
+            <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Procedure</a>
+            <a href="./qa_workflow_analysis.html" style="color: #00c875; text-decoration: none; font-weight: 500; white-space: nowrap;">Workflow</a>
+            <a href="./team_performance_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Performance</a>
+            <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Roadmap</a>
+            <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Candidate</a>
+        </div>
     </div>
 </nav>
     <div class="header">

--- a/docs/team_performance_analysis.html
+++ b/docs/team_performance_analysis.html
@@ -357,14 +357,16 @@
     <link rel="stylesheet" href="/css/share.css">
 </head>
 <body>
-<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a;">
-    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500;">← Home</a>
-    <div style="display: flex; gap: 20px; font-size: 0.9em;">
-        <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Procedure</a>
-        <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Analysis</a>
-        <a href="./team_performance_analysis.html" style="color: #00c875; text-decoration: none; font-weight: 500;">Performance</a>
-        <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Roadmap</a>
-        <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8;">Candidate</a>
+<nav style="position: sticky; top: 0; z-index: 100; background: #0f0f23; padding: 12px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #2a2a4a; gap: 12px;">
+    <a href="./index.html" style="color: #9d50dd; text-decoration: none; font-weight: 500; white-space: nowrap; flex-shrink: 0;">← Home</a>
+    <div class="nav-scroll-container" style="overflow: hidden; flex: 1; min-width: 0;">
+        <div class="nav-scroll" style="display: flex; gap: 20px; font-size: 0.9em; padding-right: 20px;">
+            <a href="./qa_manager_procedure.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Procedure</a>
+            <a href="./qa_workflow_analysis.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Analysis</a>
+            <a href="./team_performance_analysis.html" style="color: #00c875; text-decoration: none; font-weight: 500; white-space: nowrap;">Performance</a>
+            <a href="./next_steps_roadmap.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Roadmap</a>
+            <a href="./ideal_candidate_profile.html" style="color: #eee; text-decoration: none; opacity: 0.8; white-space: nowrap;">Candidate</a>
+        </div>
     </div>
 </nav>
     <div class="header">


### PR DESCRIPTION
## Summary
- Adds a gradient fade on the right edge of the mobile nav to indicate more items are scrollable
- Gradient fades out automatically when user scrolls to the end
- Applied to all pages with inline nav (all except index.html which has a hamburger menu)

## Test plan
1. Resize browser to ~375px width (mobile viewport)
2. Navigate to `qa_manager_procedure.html` or other pages
3. Verify the nav shows a gradient fade on the right edge
4. Scroll the nav horizontally to see remaining items
5. Verify the gradient disappears when scrolled to the end

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)